### PR TITLE
Make request for account ID using the zone method

### DIFF
--- a/src/inc/class-cloudflare-stream-api.php
+++ b/src/inc/class-cloudflare-stream-api.php
@@ -360,7 +360,7 @@ class Cloudflare_Stream_API {
 	 * @since 1.0.9
 	 */
 	public function get_account_id( $save = false ) {
-        $response_text = json_decode( $this->request( '', array(), false ) );
+        $response_text = json_decode( $this->request( '', array(), false, self::ZONES_API ) );
 		if ( $response_text->success ) {
 			$api_id = $response_text->result->account->id;
 			if ( strlen( $api_id ) == 32 ) {


### PR DESCRIPTION
Fixes an infinite loop of trying to _get_ the account id _using_ the account ID request method. #11 